### PR TITLE
Add definition for linked data proofs

### DIFF
--- a/index.html
+++ b/index.html
@@ -290,6 +290,8 @@
       <dt>
         <dfn data-lt="linked data proof|linked data proofs">linked data proof</dfn>
       </dt>
+      <dd>An object or mechanism for proving integrity of <a>linked data
+          documents</a>, in the form specified by [[LD-PROOFS]].</dd>
 
       <dt><dfn>EcdsaSecp256k1VerificationKey2019</dfn></dt>
       <dd>


### PR DESCRIPTION
This adds a definition for the "linked data proof" term that is in the
terminology section but currently missing a definition: https://w3c-ccg.github.io/ethereum-eip712-signature-2021-spec/#dfn-linked-data-proof