### PR TITLE
Add eip712 to context

### DIFF
--- a/contexts/v1/index.json
+++ b/contexts/v1/index.json
@@ -63,6 +63,24 @@
             }
           }
         },
+        "eip712": {
+          "@id": "https://w3c-ccg.github.io/ethereum-eip712-signature-2021-spec/#eip712-domain",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "types": {
+              "@id": "https://w3c-ccg.github.io/ethereum-eip712-signature-2021-spec/#message-schema",
+              "@type": "@json"
+            },
+            "primaryType": "https://w3c-ccg.github.io/ethereum-eip712-signature-2021-spec/#primary-type",
+            "domain": {
+              "@id": "https://w3c-ccg.github.io/ethereum-eip712-signature-2021-spec/#domain",
+              "@type": "@json"
+            }
+          }
+        },
         "proofValue": "https://w3id.org/security#proofValue",
         "verificationMethod": {
           "@id": "https://w3id.org/security#verificationMethod",


### PR DESCRIPTION
Update JSON-LD context file for changes in #32.

Add `eip712` with `types`, similar to previous `eip712Domain` with `messageSchema`.

I think it's okay to add to the existing `v1` context rather than starting a new one, since this change should not cause breakage. The existing context definition for `eip712Domain` is left in the `v1` file, also, to prevent breakage; if that is to be removed, I think that should be done in a new context file.

The IRIs for `eip712` and `types` are the same as for the previous `eip712Domain` and `messageSchema`. I think that is correct, since the objects are intended to have the same purpose/meaning.

Note that the IRIs used here do not link to valid anchors in the specification document; but the document could be updated to make these links work in a browser.