### PR TITLE
Build and deploy with spec-prod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  ci:
+    name: Build, Validate and Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: w3c/spec-prod@v2
+        with:
+          GH_PAGES_BRANCH: gh-pages


### PR DESCRIPTION
From https://github.com/w3c/spec-prod/blob/main/docs/examples.md#deploy-to-github-pages

- Build and test on pull-request
- Deploy to `gh-pages` branch on push to `main`

Deploying the built version enables the spec to work better in browsers without JavaScript, since the `ids` will all be set, etc. It will also mean a faster experience even with JS, since there will be fewer requests and processing on page load.